### PR TITLE
Add Python 3 Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='salesforce-python-toolkit',
-    version='0.1.4',
+    version='0.1.5',
     description='A fork of http://code.google.com/p/salesforce-python-toolkit/',
     url='http://github.com/BayCitizen/salesforce-python-toolkit',
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,17 @@ setup(
     packages=[
         'sforce',
     ],
-
     install_requires=[
+    ],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Natural Language :: English',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/sforce/base.py
+++ b/sforce/base.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
 # published by the Free Software Foundation; either version 3 of the 
@@ -88,18 +89,18 @@ class SforceBaseClient(object):
 
       self._sforce.set_options(headers = headers)
 
-      if kwargs.has_key('proxy'):
+      if 'proxy' in kwargs:
         # urllib2 cannot handle HTTPS proxies yet (see bottom of README)
-        if kwargs['proxy'].has_key('https'):
+        if 'https' in kwargs['proxy']:
           raise NotImplementedError('Connecting to a proxy over HTTPS not yet implemented due to a \
   limitation in the underlying urllib2 proxy implementation.  However, traffic from a proxy to \
   Salesforce will use HTTPS.')
         self._sforce.set_options(proxy = kwargs['proxy'])
 
-      if kwargs.has_key('username'):
+      if 'username' in kwargs:
         self._sforce.set_options(username = kwargs['username'])
 
-      if kwargs.has_key('password'):
+      if 'password' in kwargs:
         self._sforce.set_options(password = kwargs['password'])
 
     else:
@@ -118,7 +119,7 @@ class SforceBaseClient(object):
     try:
       return self._sforce.factory.create(sObjectType)
     except:
-      print 'There is not a SOAP header of type %s' % sObjectType
+      print('There is not a SOAP header of type %s' % sObjectType)
 
   def generateObject(self, sObjectType):
     '''

--- a/sforce/enterprise.py
+++ b/sforce/enterprise.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
 # published by the Free Software Foundation; either version 3 of the 
@@ -14,7 +15,7 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 # Written by: David Lanstein ( lanstein yahoo com )
 
-from base import SforceBaseClient
+from .base import SforceBaseClient
 
 import suds.sudsobject
 

--- a/sforce/partner.py
+++ b/sforce/partner.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the (LGPL) GNU Lesser General Public License as
 # published by the Free Software Foundation; either version 3 of the 
@@ -15,7 +16,7 @@
 # Written by: David Lanstein ( lanstein yahoo com )
 
 
-from base import SforceBaseClient
+from .base import SforceBaseClient
 
 import string
 import suds.sudsobject


### PR DESCRIPTION
This is pretty much the result of running `futurize` against this package.

There is some use of unicode literals in the tests, however the tests seem pretty useless as they require an actual org and WSDL to run.

There's plenty of opportunities to improve this package style-wise as well, but I don't think we need to concern ourselves with that right now.